### PR TITLE
[UPD] - docs and bump actions modules;

### DIFF
--- a/.github/workflows/ci-release-version.yml
+++ b/.github/workflows/ci-release-version.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-security-scanner-checks.yml
+++ b/.github/workflows/ci-security-scanner-checks.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # master
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # master
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -43,7 +43,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           output: 'trivy-results.sarif'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
         with:
           sarif_file: 'trivy-results.sarif'
         env:
@@ -100,12 +100,12 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload artifact
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # main
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # main
         with:
           name: 'OSSF Sarif file'
           path: 'ossf-results.sarif'
           retention-days: 5
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
         with:
           sarif_file: 'ossf-results.sarif'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=${{ env.VERSION }}" -o pscloud-exporter.exe ./cmd/pscloud-exporter
 
       - name: Upload binaries to GitHub Release
-        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           body_path: last_commits.txt
           tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,4 +24,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
+        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # PSCloud Exporter
 
+![Go version](https://img.shields.io/github/go-mod/go-version/atlet99/pscloud-exporter/main?style=flat&label=go-version) [![Docker Image Version](https://img.shields.io/docker/v/zetfolder17/pscloud-exporter?label=docker%20image&sort=semver)](https://hub.docker.com/r/zetfolder17/pscloud-exporter) ![Docker Image Size](https://img.shields.io/docker/image-size/zetfolder17/pscloud-exporter/latest) [![CI](https://github.com/atlet99/pscloud-exporter/actions/workflows/ci.yml/badge.svg)](https://github.com/atlet99/pscloud-exporter/actions/workflows/ci.yml) [![GitHub contributors](https://img.shields.io/github/contributors/atlet99/pscloud-exporter)](https://github.com/atlet99/pscloud-exporter/graphs/contributors/) [![Go Report Card](https://goreportcard.com/badge/github.com/atlet99/pscloud-exporter)](https://goreportcard.com/report/github.com/atlet99/pscloud-exporter) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atlet99/pscloud-exporter/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atlet99/pscloud-exporter) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/atlet99/pscloud-exporter?sort=semver)
+
 A Prometheus exporter for PS.KZ (PSCloud) services that collects metrics about your account balance, domains, and server resources via GraphQL API.
+
+Repository: [github.com/atlet99/pscloud-exporter](https://github.com/atlet99/pscloud-exporter)
 
 ## Features
 
@@ -34,6 +38,13 @@ make build
 ```bash
 docker pull zetfolder17/pscloud-exporter:latest
 ```
+
+### Prebuilt Binaries
+
+Each release contains prebuilt binaries for:
+- Linux (pscloud-exporter.linux)
+- macOS (pscloud-exporter.darwin)
+- Windows (pscloud-exporter.exe)
 
 ## Configuration
 
@@ -81,10 +92,10 @@ export PSCLOUD_TOKEN="your_access_token"
 For Docker:
 ```bash
 # Using PS_ACCOUNT_TOKEN
-docker run -e PS_ACCOUNT_TOKEN="your_access_token" -p 9116:9116 atlet99/pscloud-exporter
+docker run -e PS_ACCOUNT_TOKEN="your_access_token" -p 9116:9116 zetfolder17/pscloud-exporter
 
 # Alternative using PSCLOUD_TOKEN
-docker run -e PSCLOUD_TOKEN="your_access_token" -p 9116:9116 atlet99/pscloud-exporter
+docker run -e PSCLOUD_TOKEN="your_access_token" -p 9116:9116 zetfolder17/pscloud-exporter
 ```
 
 ### 2. Using configuration file
@@ -267,46 +278,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for a list of changes.
-
-## Alternative Configuration Instructions
-
-The exporter is configured using a YAML configuration file. By default, the exporter looks for a configuration file at `/etc/pscloud-exporter/config.yml`.
-
-### Configuration Example
-
-```yaml
-listen: ":9116"
-token: "your-api-token" # deprecated method (using environment variables is recommended)
-account_id: "your-account-id" # deprecated method (using environment variables is recommended)
-metric_prefix: "pscloud_"
-```
-
-### Environment Variables
-
-Instead of specifying authentication data in the configuration file, it is recommended to use environment variables:
-
-- `PS_ACCOUNT_TOKEN` - PS.KZ API token (preferred method)
-- `PSCLOUD_TOKEN` - alternative PS.KZ API token (can be used instead of PS_ACCOUNT_TOKEN)
-- `PSCLOUD_SERVICE_ID` - Service ID for VPC and VPS API requests (optional)
-- `PSCLOUD_BASE_URL` - Base URL for PS.KZ API (optional, default: https://console.ps.kz)
-
-## Running
-
-```bash
-# Run with a specific configuration file path
-pscloud-exporter -config /path/to/config.yml
-
-# Run using environment variables
-export PS_ACCOUNT_TOKEN="your-api-token"
-pscloud-exporter
-```
-
-## Docker
-
-```bash
-# Run using Docker
-docker run -p 9116:9116 -e PS_ACCOUNT_TOKEN="your-api-token" pscloud/exporter
-
-# or using PSCLOUD_TOKEN
-docker run -p 9116:9116 -e PSCLOUD_TOKEN="your-api-token" pscloud/exporter
-```


### PR DESCRIPTION
MR started due: [[FIX] - fix deprecated parameters in README; #2
](https://github.com/atlet99/pscloud-exporter/issues/2)

Also updated actions:

[Bump actions/dependency-review-action from 4.5.0 to 4.6.0 #13](https://github.com/atlet99/pscloud-exporter/pull/13)
[Bump github/codeql-action from 3.27.7 to 3.28.15 #12](https://github.com/atlet99/pscloud-exporter/pull/12)
[Bump softprops/action-gh-release from 2.1.0 to 2.2.1 #11](https://github.com/atlet99/pscloud-exporter/pull/11)
[Bump aquasecurity/trivy-action from 0.29.0 to 0.30.0 #10](https://github.com/atlet99/pscloud-exporter/pull/10)
[Bump actions/upload-artifact from 4.5.0 to 4.6.2 #9](https://github.com/atlet99/pscloud-exporter/pull/9)